### PR TITLE
Fixed wrong case in BundleID

### DIFF
--- a/public/json/vnc_swap_left_cmd_ctrl.json
+++ b/public/json/vnc_swap_left_cmd_ctrl.json
@@ -16,6 +16,7 @@
             {
               "type": "frontmost_application_if",
               "bundle_identifiers": [
+                "^com\\.realvnc\\.vncviewer",
                 "^com\\.realvnc\\.VNCViewer"
               ]
             }
@@ -33,6 +34,7 @@
             {
               "type": "frontmost_application_if",
               "bundle_identifiers": [
+                "^com\\.realvnc\\.vncviewer",
                 "^com\\.realvnc\\.VNCViewer"
               ]
             }


### PR DESCRIPTION
This did not work for me as bundle_identifiers are case sensitive. My VNC viewer BundleID is all lower case. I don't know when this changed so have modified the code to search for either case.